### PR TITLE
Change title from 'FFDH(E)' to 'FFDH'.

### DIFF
--- a/draft-bartle-tls-deprecate-ffdh.md
+++ b/draft-bartle-tls-deprecate-ffdh.md
@@ -1,7 +1,7 @@
 ---
-title: Deprecating FFDH(E) Ciphersuites in TLS
-abbrev: Deprecating FFDH(E)
-docname: draft-bartle-tls-deprecate-ffdhe-latest
+title: Deprecating FFDH Ciphersuites in TLS
+abbrev: Deprecating FFDH
+docname: draft-bartle-tls-deprecate-ffdh-latest
 date:
 category: std
 


### PR DESCRIPTION
This title doesn't fully encompass the content of the draft (i.e. it leaves out discouraging the use of ECDH and reuse of FFDHE keys), but since the other content doesn't involve deprecation, I'm not sure they need to be mentioned in the title.